### PR TITLE
Calc Endpoint Cleanup and HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,26 @@ Navigate to `http://127.0.0.1:5000/fruitInfo?fruit=<fruit_name>`
 
 ## How to Use the Calculator Endpoint
 
+### Manual Way
+
 Use the following template to add, subtract, multiply, or divide two numbers: 
 `http://127.0.0.1:5000/calc?x=<number>&y=<number>&op=<operator>`
 - Replace `<number>` with the numbers you want to use.
 - Replace `<operator>` with one of the following operations: `add`, `subtract`, `multiply`, `divide`.
 
+For square or square root operations, use the following template:
+`http://127.0.0.1:5000/calc?x=<number>&op=<operator>`
+- Replace `<number>` with the number you want to use.
+- Replace `<operator>` with either `square` or `sqrt`.
+
 ### Important Notes:
 - The operators must be spelled exactly as shown above, or you will receive an error.
-- If any of the variables (`x`, `y`, or `op`) are missing, you will receive an error.
-- To test this endpoint you can use ptw ./test/test_calc.py
+- If any of the variables (`x`, `y`, or `op`) are missing (Unless specified), you will receive an error.
+- To test this endpoint you can use `ptw ./test/test_calc.py`
+
+### Using HTML Form
+
+You can also use an HTML form to interact with the calculator endpoint. The form allows you to input values and select operations, then submit the form to see the result. 
 
 ## How to use the motivation Endpoint
 The /motivation endpoint provides a random motivational quote whenever accessed via a GET request. When a user sends a request to this endpoint, the app responds with one of five pre-defined motivational quotes, returned in JSON format. This allows users to easily retrieve an encouraging message with every request, making it useful for applications or websites where inspiration or daily motivation is desired. Each request will randomly select and serve one quote from the list.

--- a/app.py
+++ b/app.py
@@ -149,7 +149,7 @@ def create_app():
         if not facts:
             facts = tennis_facts
         return jsonify(random.choice(facts))
-  
+
     @app.route('/sports_fact')
     def sports_fact():
         sports_facts = [

--- a/endpoints/calc.py
+++ b/endpoints/calc.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request
+from flask import Blueprint, request, jsonify, render_template
 
 calc_bp = Blueprint('calc', __name__)
 
@@ -8,27 +8,38 @@ def calc_main():
     y = request.args.get('y')
     op = request.args.get('op')
     
-    if not (x and y and op):
-        return "Invalid Input"
+    if not op:
+        return render_template('calc.html', result="Invalid Input")
+    
+    # Replace blanks with 0
+    x = 0 if x is None or x == '' else x
+    y = 0 if y is None or y == '' else y
     
     try:
         x = int(x)
         y = int(y)
     except ValueError:
-        return "Invalid Input"
+        return render_template('calc.html', result="Invalid Input")
     
     operations = {
         'add': x + y,
         'subtract': x - y,
         'multiply': x * y,
-        'divide': x / y if y != 0 else "You cannot divide by 0",
-        'mod': x % y if y != 0 else "You cannot take modulus by 0"
+        'divide': (x / y if y != 0 else "You cannot divide by 0"),
+        'mod': (x % y if y != 0 else "You cannot take modulus by 0"),
+        'square': x * x,
+        'sqrt': (x ** 0.5 if x >= 0 else "Cannot take square root of a negative number")
     }
-    
+
     if op not in operations:
         available_operations = ', '.join(operations.keys())
-        return f"You might have spelled something wrong or there is not the option. The current options are: {available_operations}"
+        return render_template('calc.html', result=f"You might have spelled something wrong or there is not the option. The current options are: {available_operations}")
     
     result = operations[op]
-    
-    return str(result)
+    return render_template('calc.html', result=str(result))
+
+# For the tests in testing/test_calc.py to get the operations
+@calc_bp.route('/calcop', methods=['GET'])
+def calc_operators():
+    operations = ['add', 'subtract', 'multiply', 'divide', 'mod', 'square', 'sqrt']
+    return jsonify(operations)

--- a/templates/calc.html
+++ b/templates/calc.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Calculator</title>
+    <script>
+        function toggleYField() {
+            const op = document.getElementById('op').value;
+            const yField = document.getElementById('y-field');
+            yField.style.display = (op === 'square' || op === 'sqrt') ? 'none' : 'block';
+        }
+    </script>
+</head>
+<body>
+    <h1>Calculator</h1>
+    <form action="/calc" method="get">
+        <label for="x">X:</label>
+        <input type="number" id="x" name="x" required><br><br>
+        <div id="y-field">
+            <label for="y">Y:</label>
+            <input type="number" id="y" name="y"><br><br>
+        </div>
+        <label for="op">Operation:</label>
+        <select id="op" name="op" onchange="toggleYField()">
+            <option value="add">Add</option>
+            <option value="subtract">Subtract</option>
+            <option value="multiply">Multiply</option>
+            <option value="divide">Divide</option>
+            <option value="mod">Modulus</option>
+            <option value="square">Square</option>
+            <option value="sqrt">Square Root</option>
+        </select><br><br>
+        <button type="submit">Calculate</button>
+    </form>
+    <br>
+    <h2>Result:</h2>
+    <p id="result">{{ result }}</p>
+</body>
+</html>

--- a/test/test_calc.py
+++ b/test/test_calc.py
@@ -8,52 +8,93 @@ def client():
     with app.test_client() as client:
         yield client
 
-#Tests add operator
+# Tests add operator
 def test_calc_add(client):
     """Test the add operation"""
     response = client.get('/calc?x=10&y=5&op=add')
-    assert response.data.decode() == '15'
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert '15' in html_data
 
-#Tests subtract operator
+# Tests subtract operator
 def test_calc_subtract(client):
     """Test the subtract operation"""
     response = client.get('/calc?x=10&y=5&op=subtract')
-    assert response.data.decode() == '5'
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert '5' in html_data
 
-#Tests multiply operator
+# Tests multiply operator
 def test_calc_multiply(client):
     """Test the multiply operation"""
     response = client.get('/calc?x=10&y=5&op=multiply')
-    assert response.data.decode() == '50'
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert '50' in html_data
     
-#Tests divide
+# Tests divide
 def test_calc_divide(client):
     """Test the divide operation"""
     response = client.get('/calc?x=10&y=5&op=divide')
-    assert response.data.decode() == '2.0'
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert '2.0' in html_data
     
-#Tests divide by 0
+# Tests divide by 0
 def test_calc_divide_by_zero(client):
     """Test divide by zero"""
     response = client.get('/calc?x=10&y=0&op=divide')
-    assert response.data.decode() == 'You cannot divide by 0'
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert 'You cannot divide by 0' in html_data
     
-#Tests if not a valid operator
+# Tests if not a valid operator
 def test_calc_invalid_operator(client):
     """Test invalid operator"""
     response = client.get('/calc?x=10&y=5&op=wrong')
-    available_operations = 'add, subtract, multiply, divide, mod'
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    operators_response = client.get('/calcop')
+    available_operations = ', '.join(operators_response.get_json())
     expected_message = f"You might have spelled something wrong or there is not the option. The current options are: {available_operations}"
-    assert response.data.decode() == expected_message
+    assert expected_message in html_data
 
-#Tests mod operator
+# Tests mod operator
 def test_calc_mod(client):
     """Test the mod operation"""
     response = client.get('/calc?x=10&y=3&op=mod')
-    assert response.data.decode() == '1'
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert '1' in html_data
 
-#Tests mod by 0
+# Tests mod by 0
 def test_calc_mod_by_zero(client):
     """Test mod by zero"""
     response = client.get('/calc?x=10&y=0&op=mod')
-    assert response.data.decode() == 'You cannot take modulus by 0'
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert 'You cannot take modulus by 0' in html_data
+
+# Tests square operator
+def test_calc_square(client):
+    """Test the square operation"""
+    response = client.get('/calc?x=4&op=square')
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert '16' in html_data
+
+# Tests square root operator
+def test_calc_sqrt(client):
+    """Test the square root operation"""
+    response = client.get('/calc?x=16&op=sqrt')
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert '4.0' in html_data
+
+# Tests square root of a negative number
+def test_calc_sqrt_negative(client):
+    """Test the square root of a negative number"""
+    response = client.get('/calc?x=-16&op=sqrt')
+    assert response.status_code == 200
+    html_data = response.get_data(as_text=True)
+    assert 'Cannot take square root of a negative number' in html_data


### PR DESCRIPTION
Made calc use HTML template (calc.html)
Edited calc tests to suite html instead
Has HTML check for atleast one input and replaces blanks with 0
HTML tests to see if no error response
Allowed for less than 2 inputs (For square and square root)
Added HTML option to Readme

For assignment Update the API -- Week 6