### PR TITLE
perf(calc): JS to separate file, updated calc.html, calc.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,19 @@ This will start the server. From there navigate to the url and your desired endp
   - **Test File**: test_brainrot.py
 
 - **Calculator Endpoint**
-  - **Endpoint**: `GET /calc?x=<number>&y=<number>&op=<operator>`
-  - **Description**: Use the following template to add, subtract, multiply, or divide two numbers: `http://127.0.0.1:5000/calc?x=<number>&y=<number>&op=<operator>`. Replace `<number>` with the numbers you want to use, and replace `<operator>` with one of the following operations: `add`, `subtract`, `multiply`, `divide`.
+  - **Endpoint**: `GET /calc?x=<number>&y=<number>&op=<operator>` or `POST /calc`
+  - **Description**: Use the following template to add, subtract, multiply, divide, or find the modulus of two numbers: `http://127.0.0.1:5000/calc?x=<number>&y=<number>&op=<operator>`. Replace `<number>` with the numbers you want to use, and replace `<operator>` with one of the following operations: `add`, `subtract`, `multiply`, `divide`, `mod`, `power`.
     
     For square or square root operations, use the following template: `http://127.0.0.1:5000/calc?x=<number>&op=<operator>`. Replace `<number>` with the number you want to use, and replace `<operator>` with either `square` or `sqrt`.
 
-    For binary and decimal converstions, use the following template: `http://127.0.0.1:5000/calc?x=<number>&op=<operator>`. Replace `<number>` with the number you want to conver to binary or decimal with either `decimal` or `binary` respectively.
+    For binary and decimal conversions, use the following template: `http://127.0.0.1:5000/calc?x=<number>&op=<operator>`. Replace `<number>` with the number you want to convert to binary or decimal with either `decimal` or `binary` respectively.
+
+    You can also use an HTML form to interact with the calculator endpoint. The form allows you to input values and select operations, then submit the form to see the result.
   - **Important Notes**: 
     - The operators must be spelled exactly as shown above, or you will receive an error.
-    - If any of the variables (`x`, `y`, or `op`) are missing (Unless specified), you will receive an error.
-    - You can also use an HTML form to interact with the calculator endpoint. The form allows you to input values and select operations, then submit the form to see the result. 
-  - **Test File**: test_calc.py
+    - If any of the variables (`x`, `y`, or `op`) are missing (unless specified), you will receive an error.
+    - If no parameters are provided, the endpoint will render an HTML form for input.
+  - **Test File**: `test_calc.py`
 
 - **Color Hexifier Endpoint**
   - **Endpoint**: `GET /color?color=blue`

--- a/endpoints/calc.py
+++ b/endpoints/calc.py
@@ -8,8 +8,11 @@ def calc_main():
     y = request.args.get('y')
     op = request.args.get('op')
     
+    if not x and not y and not op:
+        return render_template('calc.html')
+    
     if not op:
-        return render_template('calc.html', result="Invalid Input")
+        return jsonify({"error": "Invalid Input"}), 400
     
     # Replace blanks with 0
     x = 0 if x is None or x == '' else x
@@ -19,7 +22,7 @@ def calc_main():
         x = int(x)
         y = int(y)
     except ValueError:
-        return render_template('calc.html', result="Invalid Input")
+        return jsonify({"error": "Invalid Input"}), 400
     
     operations = {
         'add': x + y,
@@ -30,18 +33,22 @@ def calc_main():
         'square': x * x,
         'sqrt': (x ** 0.5 if x >= 0 else "Cannot take square root of a negative number"),
         'decimal': (bin(x).replace("0b","") if x >= 0 else "Not compatible with negative input"),
-        'binary': ((str(int(str(x), 2))) if all(c in '01' for c in str(x)) and x >= 0 else "Not compatible format to convert to binary")
+        'binary': ((str(int(str(x), 2))) if all(c in '01' for c in str(x)) and x >= 0 else "Not compatible format to convert to binary"),
+        'power': x ** y
     }
 
     if op not in operations:
         available_operations = ', '.join(operations.keys())
-        return render_template('calc.html', result=f"You might have spelled something wrong or there is not the option. The current options are: {available_operations}")
+        return jsonify({"error": f"Invalid operation. Available operations are: {available_operations}"}), 400
     
     result = operations[op]
-    return render_template('calc.html', result=str(result))
 
-# For the tests in testing/test_calc.py to get the operations
+    if 'text/html' in request.headers.get('Accept', ''):
+        return render_template('calc.html', result=result)
+    
+    return jsonify({"result": result})
+
 @calc_bp.route('/calcop', methods=['GET'])
 def calc_operators():
-    operations = ['add', 'subtract', 'multiply', 'divide', 'mod', 'square', 'sqrt','decimal','binary']
+    operations = ['add', 'subtract', 'multiply', 'divide', 'mod', 'square', 'sqrt', 'decimal', 'binary', 'power']
     return jsonify(operations)

--- a/static/calc.js
+++ b/static/calc.js
@@ -1,0 +1,16 @@
+function toggleYField() {
+    const op = document.getElementById('op').value;
+    const yField = document.getElementById('y-field');
+    yField.style.display = (op === 'square' || op === 'sqrt' || op === 'binary' || op === 'decimal') ? 'none' : 'block';
+}
+
+document.querySelector('form').addEventListener('submit', async function(event) {
+    event.preventDefault();
+    const form = event.target;
+    const x = form.x.value;
+    const y = form.y.value;
+    const op = form.op.value;
+    const response = await fetch(`/calc?x=${x}&y=${y}&op=${op}`);
+    const data = await response.json();
+    document.getElementById('result').textContent = data.result || data.error;
+});

--- a/templates/calc.html
+++ b/templates/calc.html
@@ -4,13 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calculator</title>
-    <script>
-        function toggleYField() {
-            const op = document.getElementById('op').value;
-            const yField = document.getElementById('y-field');
-            yField.style.display = (op === 'square' || op === 'sqrt' || op === 'binary' || op === 'decimal') ? 'none' : 'block';
-        }
-    </script>
+    <script src="/static/calc.js" defer></script>
 </head>
 <body>
     <h1>Calculator</h1>
@@ -32,6 +26,7 @@
             <option value="sqrt">Square Root</option>
             <option value="decimal">Convert to Binary</option>
             <option value="binary">Convert to Decimal</option>
+            <option value="power">Power</option>
         </select><br><br>
         <button type="submit">Calculate</button>
     </form>

--- a/test/test_binaryconvert.py
+++ b/test/test_binaryconvert.py
@@ -1,76 +1,85 @@
+import pytest
+from app import create_app
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
 
 def test_status_code(client):
     response = client.get('/calc?x=5&y=&op=decimal')
     assert response.status_code == 200
-    
+
 def test_decimal(client):
     response = client.get('/calc?x=5&y=&op=decimal')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '101' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == '101'
 
 def test_binary(client):
     response = client.get('/calc?x=101&y=&op=binary')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '5' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == '5'
 
 def test_decimal_zero(client):
     response = client.get('/calc?x=0&y=&op=decimal')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '0' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == '0'
 
 def test_binary_zero(client):
     response = client.get('/calc?x=0&y=&op=binary')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '0' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == '0'
 
 def test_decimal_negative(client):
     response = client.get('/calc?x=-1&y=&op=decimal')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'Not compatible with negative input' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == 'Not compatible with negative input'
 
 def test_binary_negative(client):
     response = client.get('/calc?x=-1&y=&op=binary')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'Not compatible format to convert to binary' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == 'Not compatible format to convert to binary'
 
 def test_decimal_float(client):
     response = client.get('/calc?x=5.5&y=&op=decimal')
-    assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'Invalid Input' in html_data
+    assert response.status_code == 400
+    json_data = response.get_json()
+    assert json_data['error'] == 'Invalid Input'
 
 def test_binary_float(client):
     response = client.get('/calc?x=5.5&y=&op=binary')
-    assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'Invalid Input' in html_data
+    assert response.status_code == 400
+    json_data = response.get_json()
+    assert json_data['error'] == 'Invalid Input'
 
 def test_decimal_str(client):
     response = client.get('/calc?x=abc&y=&op=decimal')
-    assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'Invalid Input' in html_data
+    assert response.status_code == 400
+    json_data = response.get_json()
+    assert json_data['error'] == 'Invalid Input'
 
 def test_binary_str(client):
     response = client.get('/calc?x=abc&y=&op=binary')
-    assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'Invalid Input' in html_data
+    assert response.status_code == 400
+    json_data = response.get_json()
+    assert json_data['error'] == 'Invalid Input'
 
 def test_decimal_blank(client):
     response = client.get('/calc?x=&y=&op=decimal')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '0' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == '0'
 
 def test_binary_blank(client):
     response = client.get('/calc?x=&y=&op=binary')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '0' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == '0'

--- a/test/test_calc.py
+++ b/test/test_calc.py
@@ -8,93 +8,100 @@ def client():
     with app.test_client() as client:
         yield client
 
-# Tests add operator
 def test_calc_add(client):
     """Test the add operation"""
     response = client.get('/calc?x=10&y=5&op=add')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '15' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == 15
 
-# Tests subtract operator
 def test_calc_subtract(client):
     """Test the subtract operation"""
     response = client.get('/calc?x=10&y=5&op=subtract')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '5' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == 5
 
-# Tests multiply operator
 def test_calc_multiply(client):
     """Test the multiply operation"""
     response = client.get('/calc?x=10&y=5&op=multiply')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '50' in html_data
-    
-# Tests divide
+    json_data = response.get_json()
+    assert json_data['result'] == 50
+
 def test_calc_divide(client):
     """Test the divide operation"""
     response = client.get('/calc?x=10&y=5&op=divide')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '2.0' in html_data
-    
-# Tests divide by 0
+    json_data = response.get_json()
+    assert json_data['result'] == 2.0
+
 def test_calc_divide_by_zero(client):
     """Test divide by zero"""
     response = client.get('/calc?x=10&y=0&op=divide')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'You cannot divide by 0' in html_data
-    
-# Tests if not a valid operator
-def test_calc_invalid_operator(client):
-    """Test invalid operator"""
-    response = client.get('/calc?x=10&y=5&op=wrong')
-    assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    operators_response = client.get('/calcop')
-    available_operations = ', '.join(operators_response.get_json())
-    expected_message = f"You might have spelled something wrong or there is not the option. The current options are: {available_operations}"
-    assert expected_message in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == "You cannot divide by 0"
 
-# Tests mod operator
 def test_calc_mod(client):
     """Test the mod operation"""
-    response = client.get('/calc?x=10&y=3&op=mod')
+    response = client.get('/calc?x=10&y=5&op=mod')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '1' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == 0
 
-# Tests mod by 0
 def test_calc_mod_by_zero(client):
     """Test mod by zero"""
     response = client.get('/calc?x=10&y=0&op=mod')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'You cannot take modulus by 0' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == "You cannot take modulus by 0"
 
-# Tests square operator
 def test_calc_square(client):
     """Test the square operation"""
-    response = client.get('/calc?x=4&op=square')
+    response = client.get('/calc?x=10&op=square')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '16' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == 100
 
-# Tests square root operator
 def test_calc_sqrt(client):
     """Test the square root operation"""
     response = client.get('/calc?x=16&op=sqrt')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert '4.0' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == 4.0
 
-# Tests square root of a negative number
 def test_calc_sqrt_negative(client):
     """Test the square root of a negative number"""
     response = client.get('/calc?x=-16&op=sqrt')
     assert response.status_code == 200
-    html_data = response.get_data(as_text=True)
-    assert 'Cannot take square root of a negative number' in html_data
+    json_data = response.get_json()
+    assert json_data['result'] == "Cannot take square root of a negative number"
+
+def test_calc_decimal(client):
+    """Test the decimal to binary conversion"""
+    response = client.get('/calc?x=5&op=decimal')
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert json_data['result'] == '101'
+
+def test_calc_binary(client):
+    """Test the binary to decimal conversion"""
+    response = client.get('/calc?x=101&op=binary')
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert json_data['result'] == '5'
+
+def test_calc_invalid_operator(client):
+    """Test invalid operator"""
+    response = client.get('/calc?x=10&y=5&op=invalid')
+    assert response.status_code == 400
+    json_data = response.get_json()
+    assert "error" in json_data
+
+def test_calc_power(client):
+    """Test the power operation"""
+    response = client.get('/calc?x=2&y=3&op=power')
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert json_data['result'] == 8


### PR DESCRIPTION
Moved JavaScript to a separate file to clean up
Updated calc.html to include JS
Updated calc.py no more HTML template for everything, want it to be usable outside of this if called
Updated calc.py endpoint was modified to render the HTML template when accessed without query parameters or when the Accept header includes text/html
Updated calc.py endpoint to return the proper code for errors
Updated calc.py added power
Updated test_calc.py and test_binaryconvert.py to fit accordingly
Updated Readme.md to reflect changes and fixed some spelling mistakes