### PR TITLE
perf(): Repurposed the helloworld endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify, render_template
+from endpoints.welcome import welcome_bp
 from endpoints.marathonfacts import marathonFacts_bp
 from endpoints.dadjoke import dadjoke_bp
 from endpoints.brainrot import brainrot_bp
@@ -26,6 +27,7 @@ def load_items_from_file():
 def create_app():
     app = Flask(__name__)
 
+    app.register_blueprint(welcome_bp)
     app.register_blueprint(brainrot_bp)
     app.register_blueprint(dadjoke_bp)
     app.register_blueprint(math_bp)
@@ -62,9 +64,6 @@ def create_app():
             return jsonify({"message": f"Hello, {name}!"})
         return jsonify({"message": "Hello, Welcome to the API!"})
         
-    @app.route('/')
-    def hello_world():
-        return "Hello World"
 
     @app.route('/animalGuesser', methods=['GET'])
     def animal_guesser():

--- a/endpoints/welcome.py
+++ b/endpoints/welcome.py
@@ -1,0 +1,54 @@
+from flask import Flask, Blueprint, render_template_string
+import markdown
+import requests
+import os
+import subprocess
+import threading
+
+# Create a Blueprint for the welcome endpoint
+welcome_bp = Blueprint('welcome', __name__)
+
+GRIP_URL = 'http://localhost:6419'
+
+def run_grip():
+    """Function to run Grip as a subprocess."""
+    subprocess.run(["grip", "README.md"])
+
+# Start Grip in a separate thread
+grip_thread = threading.Thread(target=run_grip, daemon=True)
+grip_thread.start()
+
+@welcome_bp.route('/')
+def welcome():
+    # Render the HTML content with a welcome message and a link to the README.md served by Grip
+    return render_template_string("""
+    <!doctype html>
+    <html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <title>Welcome</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+        <style>
+            body, html {
+                height: 100%;
+            }
+            .centered {
+                height: 100%;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container centered">
+            <h1 class="my-4 text-center">Welcome to the IT4200 class API!</h1>
+            <p class="text-center">
+                <a href="{{ grip_url }}" target="_blank" class="btn btn-primary">View README.md</a>
+            </p>
+        </div>
+    </body>
+    </html>
+    """, grip_url=GRIP_URL)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ watchdog==5.0.2
 Werkzeug==3.0.3
 zipp==3.20.0
 requests==2.32.3
+markdown==3.4.3
+grip==4.6.2

--- a/test/test_helloworld.py
+++ b/test/test_helloworld.py
@@ -1,7 +1,0 @@
-
-
-def test_hello(client):
-    response = client.get('/')
-    assert response.status_code == 200
-    assert b"Hello World" in response.data
-

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -1,0 +1,31 @@
+import pytest
+from flask import Flask
+from endpoints.welcome import welcome_bp
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(welcome_bp)
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_welcome_page(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'Welcome to the IT4200 class API!' in response.data
+    assert b'View README.md' in response.data
+
+def test_grip_url(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    # Check if the Grip URL is included in the rendered HTML
+    assert b'http://localhost:6419' in response.data
+
+def test_response_content_type(client):
+    response = client.get('/')
+    assert response.content_type == 'text/html; charset=utf-8'
+
+# Additional tests can be added as needed


### PR DESCRIPTION
BREAKING CHANGE:

Repurposed the helloworld endpoint located at http://127.0.0.1:5000/ to be the welcome endpoint with the same address.
Added the welcome endpoint to its own file and imported it into app.py
Changed the returned message on the web page to be a brief welcome message and a link to a render of the README file.
Added to requirements file
Deleted test_helloworld
Created new tests (test_welcome.py)
![image](https://github.com/user-attachments/assets/da933eee-94c2-4eb7-8183-d1eba155ea6f)
