### PR TITLE
fixed the double titles

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,12 +22,6 @@
             <p class="text-gray-600">Explore our available endpoints and try them out!</p>
         </header>
 
-    <div class="container mx-auto px-4 py-8">
-        <header class="text-center mb-12">
-            <h1 class="text-4xl font-bold text-gray-800 mb-4">Flask API Explorer</h1>
-            <p class="text-gray-600">Explore our available endpoints and try them out!</p>
-        </header>
-
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
             <!-- Facts Section -->
             <div class="bg-white rounded-lg shadow-md p-6">


### PR DESCRIPTION
Fixed an issue where the index.html had two instances of the header causing there to be two titles.